### PR TITLE
Upgraded ocean and replaced python-tsp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 # lower bound set to latest known working version
 # may (likely) works with older versions as well
-dwave-ocean-sdk>=7.0.0
+dwave-ocean-sdk>=7.1.0
 osmnx>=1.9.1
 matplotlib~=3.0
 mapclassify>=2.6.0
 folium==0.15.1
 scipy>=1.10.1,<2
 dash[diskcache]==2.15.0
-python-tsp==0.4.0

--- a/solver/cvrp.py
+++ b/solver/cvrp.py
@@ -382,7 +382,7 @@ class CapacitatedVehicleRoutingProblem:
             route_costs.append(customer_demand[routes[r][:-1], routes[r][1:]].sum())
             model.add_constraint(demands[routes[r]].sum() <= c)
 
-        model.minimize(add(route_costs))
+        model.minimize(add(*route_costs))
         model.lock()
 
         return model, routes


### PR DESCRIPTION
To upgrade ocean from 7.1.0, python-tsp must be replaced as there is a dependancy incompatibility with python-tsp's dependency tsplib95 0.7.1

python-tsp has been replaced with networkx's tsp solver

**Note**: networkx's tsp solver is a greedy algorithm but it doesn't seem to affect the end-results too much due to the way we use clustering for DQM and classical. The non-greedy methods took far too long to finish.